### PR TITLE
hotfix use https instead of http for materialize submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "materialize"]
 	path = materialize
-	url = http://github.com/gitsubmit/materialize
+	url = https://github.com/gitsubmit/materialize


### PR DESCRIPTION
Got an email from GitHub on page build failure:

> The page build failed with the following error: 
> 
> The submodule registered for `./materialize` could not be cloned. Make sure it's using https:// and that it's a public repo. For more information, see https://help.github.com/articles/page-build-failed-invalid-submodule. 
