### PR TITLE
add the jwt token to every request if present

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -64,6 +64,23 @@ app.config(function($routeProvider, $httpProvider) {
 
   $httpProvider.defaults.useXDomain = true
   // delete $httpProvider.defaults.headers.common['X-Requested-With']
+  $httpProvider.interceptors.push(function ($q, $location, $localStorage) {
+    return {
+      'request': function (config) {
+        config.headers = config.headers || {}
+        if ($localStorage.token) {
+          config.headers.Authorization = 'Bearer ' + $localStorage.token
+        }
+        return config
+      },
+      'responseError': function (response) {
+        // if (response.status === 401 || response.status === 403) {
+        //   $location.path('/')
+        // }
+        return $q.reject(response)
+      }
+    }
+  })
 })
 
 app.factory('escapeHtml', function() {


### PR DESCRIPTION
The jwt token is attached to every request to the server in the `Authorization` header, e.g. `Authorization: Bearer <token>`. You can then decode/verify the token to get all the information.
